### PR TITLE
Add support for character counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ Path to (what is hopefully) an epub file. Opens it, and returns a promise that r
 
 Object of options. It's optional, I don't know your life.
 
-| key | type | function | default |
-| --- | --- | --- | --- |
-print | boolean | print a nice message with data included for each file | false
-sturdy | boolean | bravely ignore errors on missing or malformed epub file | false
-quiet | boolean | stifle errors in parsing chapters | false
+| key    | type    | function                                                 | default |
+| ------ | ------- | -------------------------------------------------------- | ------- |
+| print  | boolean | print a nice message with data included for each file    | false   |
+| sturdy | boolean | bravely ignore errors on missing or malformed epub file  | false   |
+| quiet  | boolean | stifle errors in parsing chapters                        | false   |
+| chars  | boolean | count characters, including spaces, instead of words.    | false   |
+| text   | boolean | output the cleaned text which would be used for counting | false   |
 
 ## Tests
 

--- a/cli.ts
+++ b/cli.ts
@@ -57,6 +57,7 @@ cli
     'print warnings about inidividual chapters being weird; helpful for narrowing down parsing errors'
   )
   .option('-c, --chars', 'count characters instead of words')
+  .option('-t, --text', 'output the text content instead of a number')
   // .option('-r, --recurse', 'if PATH is a directory, also act on subdirectories')
   .parse(process.argv)
 
@@ -70,7 +71,8 @@ let opts: wc.Options = {
   print: !cli.raw,
   sturdy: !cli.sturdy,
   quiet: !cli.loud,
-  chars: cli.chars
+  chars: cli.chars,
+  text: cli.text
 }
 
 parsePath(fpath, opts)

--- a/cli.ts
+++ b/cli.ts
@@ -6,25 +6,25 @@ import path = require('path')
 
 import cli = require('commander')
 
-import updateNotifier = require('update-notifier');
-const pkg = require('./package.json');
-updateNotifier({ pkg }).notify();
+import updateNotifier = require('update-notifier')
+const pkg = require('./package.json')
+updateNotifier({ pkg }).notify()
 
 async function parsePath(fpath: string, opts: wc.Options) {
   try {
     const stat = await fs.stat(fpath)
     if (stat.isDirectory()) {
       const files = await fs.readdir(fpath)
-      return Promise
-        .all(files.map(async (f) => {
+      return Promise.all(
+        files.map(async f => {
           const filepath = path.join(fpath, f)
           return parseFile(filepath, opts)
-        }))
-        .then(res => {
-          return res.filter(c => c)
         })
+      ).then(res => {
+        return res.filter(c => c)
+      })
     } else {
-      return parseFile(fpath, opts).then(res => [res])
+      return parseFile(fpath, opts).then(res => res)
     }
   } catch (e) {
     console.error(`Unable to find anything at path "${fpath}"`)
@@ -36,7 +36,9 @@ async function parseFile(filepath: string, opts: wc.Options) {
   let stat = await fs.stat(filepath)
   if (!stat.isDirectory() && filepath.endsWith('epub')) {
     return wc.countWords(filepath, opts)
-  } else { return 0 }
+  } else {
+    return 0
+  }
 }
 
 // MAIN
@@ -45,10 +47,7 @@ cli
   .usage('[options] PATH')
   .description('count the words in an epub file')
   .version(require('./package.json').version)
-  .option(
-    '-r, --raw',
-    'print out an array of word counts without the frivolty'
-  )
+  .option('-r, --raw', 'print out an array of word counts without the frivolty')
   .option(
     '-f, --fragile',
     'fail on malformed epub files; default: print but skip'
@@ -57,6 +56,7 @@ cli
     '-l, --loud',
     'print warnings about inidividual chapters being weird; helpful for narrowing down parsing errors'
   )
+  .option('-c, --chars', 'count characters instead of words')
   // .option('-r, --recurse', 'if PATH is a directory, also act on subdirectories')
   .parse(process.argv)
 
@@ -69,7 +69,8 @@ const fpath = cli.args[0]
 let opts: wc.Options = {
   print: !cli.raw,
   sturdy: !cli.sturdy,
-  quiet: !cli.loud
+  quiet: !cli.loud,
+  chars: cli.chars
 }
 
 parsePath(fpath, opts)

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,5 +3,6 @@ export interface Options {
     sturdy?: boolean;
     quiet?: boolean;
     chars?: boolean;
+    text?: boolean;
 }
-export declare function countWords(path: string, options?: Options): Promise<number>;
+export declare function countWords(path: string, options?: Options): Promise<string | number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,5 +2,6 @@ export interface Options {
     print?: boolean;
     sturdy?: boolean;
     quiet?: boolean;
+    chars?: boolean;
 }
 export declare function countWords(path: string, options?: Options): Promise<number>;

--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ function cleanText(text: string) {
   const res = text
     // these are replaced by spaces so that newlines in the text are properly tokenized
     .replace(htmlRegex, ' ')
-    .replace(/[\n\t\r]/g, ' ')
+    .replace(/[\n\t\r\s]+/g, ' ')
   // console.log(res)
   return res
 }

--- a/index.ts
+++ b/index.ts
@@ -5,20 +5,21 @@ import EPub = require('epub')
 import _ = require('lodash')
 
 export interface Options {
-  print?: boolean,
-  sturdy?: boolean,
+  print?: boolean
+  sturdy?: boolean
   quiet?: boolean
+  chars?: boolean
 }
 
 type PromisifyEvent = (server: any, event: string) => Promise<void>
-const promisifyEvent:PromisifyEvent = require('promisify-event')
+const promisifyEvent: PromisifyEvent = require('promisify-event')
 
 const ignoredTitlesRegex = /acknowledgment|copyright|cover|dedication|title|author|contents/i
 // match all html tags, no matter their contents
-const htmlRegex = /(<([^>]+)>)/ig
+const htmlRegex = /(<([^>]+)>)/gi
 
 // takes a path to an ebook file
-export async function countWords (path: string, options?: Options) {
+export async function countWords(path: string, options?: Options) {
   const defaults: Options = { print: false, sturdy: false, quiet: false }
   const opts = _.merge({}, defaults, options)
 
@@ -36,43 +37,64 @@ export async function countWords (path: string, options?: Options) {
 
   await promisifyEvent(epub, 'end')
   if (!opts.sturdy && epub.hasDRM()) {
-    throw new Error(`Unable to accurately count "${epub.metadata.title}" because it is DRM protected`)
+    throw new Error(
+      `Unable to accurately count "${epub.metadata.title}" because it is DRM protected`
+    )
   } else {
     return main(epub, opts)
   }
 }
 
-function cleanText (text: string) {
+function cleanText(text: string) {
   const res = text
     // these are replaced by spaces so that newlines in the text are properly tokenized
     .replace(htmlRegex, ' ')
     .replace(/[\n\t\r]/g, ' ')
-    .split(' ')
-    .filter(x => x.trim() !== '')
   // console.log(res)
   return res
 }
 
-function chapterLength (id: string, epub: EPub): Promise<number> {
-  return new Promise(function (resolve, reject) {
+function nWords(text: string) {
+  return text.split(' ').filter(x => x.trim() !== '').length
+}
+
+function nCount(options: Options, text: string) {
+  const clean = cleanText(text)
+  return options.chars ? clean.length : nWords(clean)
+}
+
+function chapterLength(
+  id: string,
+  epub: EPub,
+  options: Options
+): Promise<number> {
+  return new Promise(function(resolve, reject) {
     // using this instead of getChapterRaw, which pulls out style and stuff for me
-    epub.getChapter(id, function (err: Error, text: string) {
-      if (err) { reject(err) }
-      resolve(cleanText(text).length)
+    epub.getChapter(id, function(err: Error, text: string) {
+      if (err) {
+        reject(err)
+      }
+
+      resolve(nCount(options, text))
     })
   })
 }
 
-async function main (epub: EPub, options: Options) {
+async function main(epub: EPub, options: Options) {
   let total = 0
-  const promises = epub.flow.map(async (chapter) => {
-    if (chapter.title === undefined || !chapter.title.match(ignoredTitlesRegex)) {
+  const promises = epub.flow.map(async chapter => {
+    if (
+      chapter.title === undefined ||
+      !chapter.title.match(ignoredTitlesRegex)
+    ) {
       try {
-        const res = await chapterLength(chapter.id, epub)
+        const res = await chapterLength(chapter.id, epub, options)
         total += res
       } catch (e) {
         if (!options.quiet) {
-          console.log(`Issue with chapter ${chapter.id} in book ${epub.metadata.title}`)
+          console.log(
+            `Issue with chapter ${chapter.id} in book ${epub.metadata.title}`
+          )
         }
       }
     }
@@ -88,7 +110,10 @@ async function main (epub: EPub, options: Options) {
       // if there's DRM, the answer is way too low
       console.log(' * DRM detected')
     } else {
-      console.log(` * ${total.toLocaleString()} words`)
+      console.log(
+        ` * ${total.toLocaleString()} ` +
+          (options.chars ? 'characters' : 'words')
+      )
     }
     console.log()
   }

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,10 @@
 'use strict'
 
 import EPub = require('epub')
+import decode = require('parse-entities')
 
 import _ = require('lodash')
+// import { decode } from './unicode'
 
 export interface Options {
   print?: boolean
@@ -52,7 +54,7 @@ function cleanText(text: string) {
     .replace(htmlRegex, ' ')
     .replace(/[\n\t\r\s]+/g, ' ')
   // console.log(res)
-  return res
+  return decode(res)
 }
 
 function nWords(text: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,21 @@
         }
       }
     },
+    "character-entities": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -377,6 +392,20 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
+    "is-alphabetical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -387,10 +416,20 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-decimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-hexadecimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
     },
     "is-npm": {
       "version": "1.0.0",
@@ -539,6 +578,19 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      }
+    },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "path-key": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epub-wordcount",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,44 +8,49 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.9.1.tgz",
       "integrity": "sha512-P4s1aEJYjHB1pmS5th4WXQ/NEYykK1FmCFJL+NIrDCptWs2DIS/SsVjmaubvcWZ17VzlG+CwiAv52ghkfkepWA==",
+      "dev": true,
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "*"
       }
     },
     "@types/lodash": {
       "version": "4.14.70",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.70.tgz",
-      "integrity": "sha512-uvDjWW3m7SFUhSpohfQvj32gRsVgRxA0Z0OfMJh8m/JuX4YJLHeEwRBuHJgvNgTAVBpJDFKVFeyrREuMwkE9Qw=="
+      "integrity": "sha512-uvDjWW3m7SFUhSpohfQvj32gRsVgRxA0Z0OfMJh8m/JuX4YJLHeEwRBuHJgvNgTAVBpJDFKVFeyrREuMwkE9Qw==",
+      "dev": true
     },
     "@types/mz": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.31.tgz",
       "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
+      "dev": true,
       "requires": {
-        "@types/node": "8.0.14"
+        "@types/node": "*"
       }
     },
     "@types/node": {
       "version": "8.0.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.14.tgz",
-      "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w=="
+      "integrity": "sha512-lrtgE/5FeTdcuxgsDbLUIFJ33dTp4TkbKkTDZt/ueUMeqmGYqJRQd908q5Yj9EzzWSMonEhMr1q/CQlgVGEt4w==",
+      "dev": true
     },
     "@types/update-notifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.1.tgz",
-      "integrity": "sha1-R+jwB8a1vK++QnMy47a0M83Bjdw="
+      "integrity": "sha1-R+jwB8a1vK++QnMy47a0M83Bjdw=",
+      "dev": true
     },
     "adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       }
     },
     "ansi-regex": {
@@ -58,7 +63,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
       "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "^1.0.0"
       }
     },
     "any-promise": {
@@ -71,13 +76,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.0.tgz",
       "integrity": "sha512-tfKK3nq0qXXOxvXEYW1k1XNRrDuQzO2oFPvLD3Fs1I58n0leuTNlftBmu3seUCyZvDfiqgRaxlqZs9WJAbSA7g==",
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.0.1",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^1.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -85,9 +90,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
           "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
           "requires": {
-            "ansi-styles": "3.1.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         }
       }
@@ -107,11 +112,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -129,7 +134,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -154,7 +159,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -172,12 +177,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "requires": {
-        "dot-prop": "4.1.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "create-error-class": {
@@ -185,7 +190,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -193,9 +198,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.2.14"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-random-string": {
@@ -208,12 +213,20 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "dot-prop": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.1.tgz",
       "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer3": {
@@ -223,17 +236,45 @@
     },
     "epub": {
       "version": "github:xavdid/epub#7efbcf2824ffee5bba6eba34d0c4bd4291ab55c6",
+      "from": "github:xavdid/epub",
       "requires": {
-        "@types/node": "6.0.84",
-        "adm-zip": "0.4.7",
-        "xml2js": "0.4.17"
+        "@types/node": "^6.0.38",
+        "adm-zip": "^0.4.4",
+        "xml2js": "^0.4.4"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.84",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.84.tgz",
-          "integrity": "sha512-1SvEazClhUBRNroJM3oB3xf3u2r6xGmHDGbdigqNPHvNKLl8/BtATgO9eC04ZLuovpSh0B20BF1QJxdi+qmTlg=="
+          "version": "6.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.7.tgz",
+          "integrity": "sha512-YbPXbaynBTe0pVExPhL76TsWnxSPeFAvImIsmylpBWn/yfw+lHy+Q68aawvZHsgskT44ZAoeE67GM5f+Brekew=="
         }
+      }
+    },
+    "es-abstract": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -246,14 +287,19 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -265,17 +311,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -283,12 +329,20 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -302,6 +356,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -317,6 +376,16 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -338,6 +407,14 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -347,6 +424,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -358,7 +443,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lodash": {
@@ -376,8 +461,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -385,7 +470,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
       "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.3.0"
       }
     },
     "minimist": {
@@ -398,9 +483,9 @@
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
       "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "npm-run-path": {
@@ -408,7 +493,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -421,6 +506,25 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -431,10 +535,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "path-key": {
@@ -457,7 +561,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "prepend-http": {
@@ -470,7 +574,7 @@
       "resolved": "https://registry.npmjs.org/promisify-event/-/promisify-event-1.0.0.tgz",
       "integrity": "sha1-vXUj6ga3AWLzcJeQFrU6aGxg6Q8=",
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pseudomap": {
@@ -483,10 +587,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "registry-auth-token": {
@@ -494,8 +598,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "requires": {
-        "rc": "1.2.1",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -503,7 +607,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.1"
+        "rc": "^1.0.1"
       }
     },
     "safe-buffer": {
@@ -526,7 +630,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.3.0"
+        "semver": "^5.0.3"
       }
     },
     "shebang-command": {
@@ -534,7 +638,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -557,8 +661,26 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "strip-ansi": {
@@ -566,7 +688,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-eof": {
@@ -584,7 +706,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.0.tgz",
       "integrity": "sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==",
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "term-size": {
@@ -592,7 +714,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "thenify": {
@@ -600,7 +722,7 @@
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -608,7 +730,7 @@
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "timed-out": {
@@ -627,7 +749,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unzip-response": {
@@ -640,14 +762,14 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
       "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
       "requires": {
-        "boxen": "1.2.0",
-        "chalk": "1.1.3",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.0.0",
+        "chalk": "^1.0.0",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "url-parse-lax": {
@@ -655,7 +777,16 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
+      }
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "which": {
@@ -663,7 +794,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "widest-line": {
@@ -671,7 +802,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -684,7 +815,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -692,9 +823,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -702,7 +833,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -712,9 +843,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
       "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "xdg-basedir": {
@@ -723,21 +854,19 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "util.promisify": "~1.0.0",
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "epub-wordcount",
+  "name": "@swann-studio/epub-wordcount",
   "version": "1.3.0",
   "description": "Count the number of words in an ebook",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swann-studio/epub-wordcount",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Count the number of words in an ebook",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "Count the number of words in an ebook",
   "main": "index.js",
   "dependencies": {
-    "@types/commander": "^2.9.0",
-    "@types/lodash": "^4.14.34",
-    "@types/mz": "0.0.31",
-    "@types/update-notifier": "^1.0.1",
     "commander": "^2.9.0",
     "epub": "xavdid/epub",
     "lodash": "^4.15.0",
@@ -18,20 +14,25 @@
   "bin": {
     "word-count": "./cli.js"
   },
-  "typings": "index.d.ts",
+  "types": "index.d.ts",
   "devDependencies": {
-    "typescript": "^2.0.2"
+    "typescript": "^2.0.2",
+    "@types/commander": "^2.9.0",
+    "@types/lodash": "^4.14.34",
+    "@types/mz": "0.0.31",
+    "@types/update-notifier": "^1.0.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "version": "tsc",
-    "postversion": "git push && git push --tags && npm publish"
+    "postversion": "git push && git push --tags && npm publish",
+    "build": "npx tsc"
   },
   "keywords": [
     "epub",
     "ebook",
     "stats"
   ],
-  "author": "David Brownman <beamneocube@gmail.com> (https://davidbrownman.com)",
+  "author": "Jakob Lund <jl@swann-studio.com>",
   "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "epub": "xavdid/epub",
     "lodash": "^4.15.0",
     "mz": "^2.6.0",
+    "parse-entities": "^1.2.2",
     "promisify-event": "^1.0.0",
     "update-notifier": "^2.2.0"
   },

--- a/parse-entities.d.ts
+++ b/parse-entities.d.ts
@@ -1,0 +1,1 @@
+declare module 'parse-entities'


### PR DESCRIPTION
We count characters in pdf manuscripts using `pdftotext | wc -m`, and we needed an epub equivalent. This is what we currently use; 

Added `parse-entities` in order to get correct character counts of things like &#27; (the "ø" character)

